### PR TITLE
Shared types UUID

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,6 +25,10 @@ jobs:
         with:
           components: rustfmt
 
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 7.32.2
+
       - name: Check formatting
         shell: bash
         run: cargo fmt --all --check
@@ -103,7 +107,7 @@ jobs:
 
       - uses: pnpm/action-setup@v2
         with:
-          version: 7.18.1
+          version: 7.32.2
 
       - name: Check formatting
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,6 +248,7 @@ dependencies = [
  "async-channel",
  "bcs",
  "crossbeam-channel",
+ "crux_http",
  "crux_macros",
  "derive_more",
  "futures",

--- a/crux_core/Cargo.toml
+++ b/crux_core/Cargo.toml
@@ -29,11 +29,13 @@ wasm-bindgen = "0.2.84"
 
 [dev-dependencies]
 assert_matches = "1.5"
+async-channel = "1.8"
 crux_macros = { version = "0.2", path = "../crux_macros" }
+crux_http = { version = "0.3", path = "../crux_http" }
 serde = { version = "1.0.160", features = ["derive"] }
 static_assertions = "1.1"
-async-channel = "1.8"
 rand = "0.8"
+uuid = { version = "1.3.1", features = ["v4", "serde"] }
 
 [features]
 typegen = ["dep:serde-generate", "dep:serde-reflection"]

--- a/crux_core/tests/typegen.rs
+++ b/crux_core/tests/typegen.rs
@@ -1,0 +1,66 @@
+mod shared {
+    use crux_http::Http;
+    use crux_macros::Effect;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Default)]
+    pub struct App;
+
+    #[derive(Serialize, Deserialize)]
+    pub enum Event {
+        None,
+        SendUuid(uuid::Uuid),
+    }
+    #[derive(Serialize, Deserialize)]
+    pub struct ViewModel;
+    impl crux_core::App for App {
+        type Event = Event;
+        type Model = ();
+        type ViewModel = ViewModel;
+        type Capabilities = Capabilities;
+        fn update(&self, _event: Event, _model: &mut Self::Model, _caps: &Capabilities) {}
+        fn view(&self, _model: &Self::Model) -> Self::ViewModel {
+            todo!();
+        }
+    }
+
+    #[derive(Effect)]
+    pub struct Capabilities {
+        pub http: Http<Event>,
+    }
+}
+mod test {
+    use super::shared::{EffectFfi, Event, ViewModel};
+    use crux_core::{bridge::Request, typegen::TypeGen};
+    use crux_http::protocol::{HttpRequest, HttpResponse};
+    use std::env::temp_dir;
+    use uuid::Uuid;
+
+    #[test]
+    fn generate_types() {
+        let mut gen = TypeGen::new();
+
+        gen.register_type::<Request<EffectFfi>>().unwrap();
+
+        gen.register_type::<EffectFfi>().unwrap();
+        gen.register_type::<HttpRequest>().unwrap();
+
+        let sample_events = vec![Event::SendUuid(Uuid::new_v4())];
+        gen.register_type_with_samples(sample_events).unwrap();
+
+        gen.register_type::<HttpResponse>().unwrap();
+
+        gen.register_type::<ViewModel>().unwrap();
+
+        let output_root = temp_dir().join("crux_core_typegen_test");
+
+        gen.swift("shared_types", output_root.join("swift"))
+            .expect("swift type gen failed");
+
+        gen.java("com.example.counter.shared_types", output_root.join("java"))
+            .expect("java type gen failed");
+
+        gen.typescript("shared_types", output_root.join("typescript"))
+            .expect("typescript type gen failed");
+    }
+}

--- a/examples/counter/Cargo.lock
+++ b/examples/counter/Cargo.lock
@@ -4319,7 +4319,7 @@ dependencies = [
  "crux_platform",
  "crux_time",
  "shared",
- "uuid 1.3.1",
+ "uuid 1.3.2",
 ]
 
 [[package]]

--- a/examples/counter/shared/shared.xcodeproj/xcuserdata/stuartharris.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/examples/counter/shared/shared.xcodeproj/xcuserdata/stuartharris.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,12 +7,12 @@
 		<key>shared-cdylib.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>3</integer>
 		</dict>
 		<key>shared-staticlib.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>3</integer>
+			<integer>0</integer>
 		</dict>
 		<key>uniffi-bindgen-bin.xcscheme_^#shared#^_</key>
 		<dict>

--- a/examples/counter/shared_types/build.rs
+++ b/examples/counter/shared_types/build.rs
@@ -31,7 +31,7 @@ fn register_types(gen: &mut TypeGen) -> Result<()> {
     gen.register_type::<HttpRequest>()?;
 
     let sample_events = vec![Event::SendUuid(Uuid::new_v4())];
-    gen.register_type_with_samples::<Event>(sample_events)?;
+    gen.register_type_with_samples(sample_events)?;
 
     gen.register_type::<HttpResponse>()?;
     gen.register_type::<SseResponse>()?;


### PR DESCRIPTION
@wasnotrice Hi! I decided to have a go at fixing the doc tests, and whilst adding an integration test I couldn't understand why it was failing (when it works for you!) :-) 

Found out that the variant that uses custom deserialization can't be the first variant (because `serde_refelction`), so added that to the docs and error message in case anyone else hits the same thing.

Big thanks for contributing this. If you're happy, merge this into yours and then I'll merge yours into master.

All the best
Stu